### PR TITLE
Fixes to allow an application using jdbc-driver to start the containe…

### DIFF
--- a/src/main/java/foundation/stack/jdbc/DockerDatabaseServerContainerReferenceManager.java
+++ b/src/main/java/foundation/stack/jdbc/DockerDatabaseServerContainerReferenceManager.java
@@ -16,7 +16,7 @@ public class DockerDatabaseServerContainerReferenceManager extends ContainerMana
 
     private static Logger logger = Logger.getLogger(DockerDatabaseServerContainerReferenceManager.class.getName());
 
-    public static final String ROOT_PASSWORD_PROPERTY = "ROOT_PASSWORD";
+    static final String ROOT_PASSWORD_PROPERTY = "root.password";
     private static final String DEFAULT_ROOT_PASSWORD = null;
 
     private static final String APPLICATION_USER_NAME_PROPERTY = "APPLICATION_USER_NAME";

--- a/src/main/java/foundation/stack/jdbc/DockerDatabaseServerContainerReferenceManager.java
+++ b/src/main/java/foundation/stack/jdbc/DockerDatabaseServerContainerReferenceManager.java
@@ -16,7 +16,7 @@ public class DockerDatabaseServerContainerReferenceManager extends ContainerMana
 
     private static Logger logger = Logger.getLogger(DockerDatabaseServerContainerReferenceManager.class.getName());
 
-    private static final String ROOT_PASSWORD_PROPERTY = "ROOT_PASSWORD";
+    public static final String ROOT_PASSWORD_PROPERTY = "ROOT_PASSWORD";
     private static final String DEFAULT_ROOT_PASSWORD = null;
 
     private static final String APPLICATION_USER_NAME_PROPERTY = "APPLICATION_USER_NAME";
@@ -64,7 +64,7 @@ public class DockerDatabaseServerContainerReferenceManager extends ContainerMana
     }
 
     protected String createContainerReference(ContainerProperties containerProperties) {
-        int sqlServerPort = Integer.parseInt(containerProperties.getOriginalDefinition().getPortMappings().entrySet().iterator().next().getKey());
+        int sqlServerPort = Integer.parseInt(containerProperties.getOriginalDefinition().getPortMappings().entrySet().iterator().next().getValue());
         try {
             waitBrieflyForDatabaseServerConnect(containerProperties.getHostIp(), sqlServerPort);
         } catch (InterruptedException e) {

--- a/src/main/java/foundation/stack/jdbc/DockerDatabaseServerContainerReferenceManager.java
+++ b/src/main/java/foundation/stack/jdbc/DockerDatabaseServerContainerReferenceManager.java
@@ -64,7 +64,7 @@ public class DockerDatabaseServerContainerReferenceManager extends ContainerMana
     }
 
     protected String createContainerReference(ContainerProperties containerProperties) {
-        int sqlServerPort = Integer.parseInt(containerProperties.getOriginalDefinition().getPortMappings().entrySet().iterator().next().getValue());
+        int sqlServerPort = containerProperties.getPublishedPorts().entrySet().iterator().next().getValue().getPort();
         try {
             waitBrieflyForDatabaseServerConnect(containerProperties.getHostIp(), sqlServerPort);
         } catch (InterruptedException e) {

--- a/src/main/java/foundation/stack/jdbc/DockerDatabaseServerPerApplicationConnectionLookup.java
+++ b/src/main/java/foundation/stack/jdbc/DockerDatabaseServerPerApplicationConnectionLookup.java
@@ -104,8 +104,7 @@ public class DockerDatabaseServerPerApplicationConnectionLookup implements Conne
                         NameGenerator.generateDatabaseName());
                 return appendDatabaseName(containerConnectionString, databaseName);
             } else {
-                String databaseName = databaseManager.getOrCreateNamedDatabase(containerConnectionString,
-                        NameGenerator.generateDatabaseName());
+                String databaseName = databaseManager.getOrCreateNamedDatabase(containerConnectionString, query);
                 return appendDatabaseName(containerConnectionString, databaseName);
             }
         } catch (ExecutionException | SQLException e) {

--- a/src/main/java/foundation/stack/jdbc/DockerDatabaseServerPerApplicationConnectionLookup.java
+++ b/src/main/java/foundation/stack/jdbc/DockerDatabaseServerPerApplicationConnectionLookup.java
@@ -92,7 +92,7 @@ public class DockerDatabaseServerPerApplicationConnectionLookup implements Conne
             String versionTag = System.getProperty(MYSQL_IMAGE_TAG_PROPERTY, MYSQL_VERSION);
 
             ContainerSpecification containerSpecification = new ContainerSpecification(imageName, versionTag);
-            containerSpecification.addPortMapping(MYSQL_PORT, getAvailablePort());
+            containerSpecification.addPortMapping(MYSQL_PORT, null);
             addRootPasswordEnvironmentVariable(containerSpecification, applicationName);
 
             String containerConnectionString = getContainerReferenceManager()
@@ -120,14 +120,5 @@ public class DockerDatabaseServerPerApplicationConnectionLookup implements Conne
         }
         containerSpecification.addEnvironmentVariable(MYSQL_ROOT_PASSWORD, rootPassword);
         System.setProperty(ROOT_PASSWORD_PROPERTY, rootPassword);
-    }
-
-    private Integer getAvailablePort() {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            logger.log(Level.FINE, "Could not get a random available port");
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/main/java/foundation/stack/jdbc/NameGenerator.java
+++ b/src/main/java/foundation/stack/jdbc/NameGenerator.java
@@ -22,12 +22,13 @@ import java.util.logging.Logger;
 public class NameGenerator {
 	private static final Logger logger = Logger.getLogger(DelegatingDriver.class.getName());
 
-	private static final String APPLICATION_NAME = "applicationName";
+	private static final String APPLICATION_NAME = "application.name";
 	private final static String GENERATED_APP_NAME = "APP-NAME-%s";
+	private final static String GIT_EXTENSION = ".git";
 
 	private static File findGitRoot(File file) {
         while (file != null) {
-            File gitDirectory = new File(file, ".git");
+            File gitDirectory = new File(file, GIT_EXTENSION);
             if (gitDirectory.exists() && gitDirectory.isDirectory()) {
                 return gitDirectory;
             }
@@ -163,7 +164,7 @@ public class NameGenerator {
             for (int i = 0; i < segments.length; i++) {
                 String segment = segments[i];
 
-                if (segment.endsWith(".git")) {
+                if (segment.endsWith(GIT_EXTENSION)) {
                     segment = segment.substring(0, segment.length() - 4);
                 }
 

--- a/src/main/java/foundation/stack/jdbc/NameGenerator.java
+++ b/src/main/java/foundation/stack/jdbc/NameGenerator.java
@@ -16,19 +16,12 @@ import java.security.CodeSource;
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public class NameGenerator {
-    private static final String JDBC_DRIVER_PACKAGE = DockerDatabaseServerPerApplicationConnectionLookup.class.getPackage().getName();
 
     private static String getCallerClassName() {
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         if (stackTrace != null && stackTrace.length > 0) {
-            for (int i = 1; i < stackTrace.length; i++) {
-                StackTraceElement element = stackTrace[i];
-                String className = element.getClassName();
-
-                if (!className.startsWith(JDBC_DRIVER_PACKAGE)) {
-                    return className;
-                }
-            }
+            int index = stackTrace.length == 1 ? 0 : stackTrace.length - 1;
+            return stackTrace[index].getClassName();
         }
 
         return null;


### PR DESCRIPTION
…r and connect to it.
- Cache ConnectionLookupResults for a query string to avoid pooled connections recreating the container for every connection. Hack until we figure out if there is an issue with container references cache.
- Try connecting to the host port (assigned now to specification).
- Use application name as root password if none is provided as system property.
- Fix name generator.
